### PR TITLE
disable toc until supported

### DIFF
--- a/data/asciidocify.js
+++ b/data/asciidocify.js
@@ -13,7 +13,7 @@ var asciidocify = {
 };
 
 var ASCIIDOCTOR_OPTIONS = Opal.hash2([ 'attributes' ], {
-    'attributes':[ 'notitle!' ]
+    'attributes':[ 'showtitle', 'toc!', 'toc2!' ]
 });
 
 /**


### PR DESCRIPTION
Disable the toc attributes until we are able to support them. This prevents Asciidoctor from crashing if these attributes are set in the document.
