### PR TITLE
Add shortcut to allow raw-mode switching

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -51,7 +51,7 @@ exports.main = function () {
     var { Hotkey } = require("sdk/hotkeys");
 
     Hotkey({
-      combo: "accel-shift-p",
+      combo: "accel-shift-d",
       onPress: function() {
         button.click();
       }

--- a/lib/main.js
+++ b/lib/main.js
@@ -47,6 +47,16 @@ exports.main = function () {
       checked: enabled
     });
 
+    // HotKey is only supported in Firefox
+    var { Hotkey } = require("sdk/hotkeys");
+
+    Hotkey({
+      combo: "accel-shift-p",
+      onPress: function() {
+        button.click();
+      }
+    });
+
     tabs.on('ready', convertAsciiDocAndRender);
 
   } else {


### PR DESCRIPTION
Use 'accel-shift-p' (for preview) hot key.

> accel: The key used for keyboard shortcuts on the user's platform,
> which is Control on Windows and Linux, and Command on Mac.
> Usually, this would be the value you would use.

See https://developer.mozilla.org/en-US/Add-ons/SDK/High-Level_APIs/hotkeys

Resolves #27
