### PR TITLE
Resolves #40, handle URI with query parameters

### DIFF
--- a/data/asciidocify.js
+++ b/data/asciidocify.js
@@ -5,7 +5,8 @@ self.port.on('RENDER_SANITIZED_HTML', function(message) {
 var asciidocify = {
   load: function() {
     var contentType = document.contentType;
-    var regexpAdFile = /\.a(sciidoc|doc|d|sc)$/i;
+    // ending with .asciidoc, .adoc, .ad or .asc OR containing .asciidoc?, .adoc?, .ad? or .asc?
+    var regexpAdFile = /\.a(sciidoc|doc|d|sc)$|\.a(sciidoc|doc|d|sc)\?|/i;
     var isAsciiDocFile = regexpAdFile.test(document.location);
     var isHTMLContent = contentType && (contentType.indexOf('html') > -1);
     if (isAsciiDocFile && !isHTMLContent) {


### PR DESCRIPTION
The regexp could be simpler:

```regepx
/\.a(sciidoc|doc|d|sc)/i
```

Meaning, containing `.asciidoc`, `.adoc`, `.ad`, `.asc` but I think this is too vague.
Instead I'm using a more complex regexp:

```
/\.a(sciidoc|doc|d|sc)$|\.a(sciidoc|doc|d|sc)\?|/i
```

Meaning, ending with `.asciidoc`, `.adoc`, `.ad` or `.asc` OR containing `.asciidoc?`, `.adoc?`, `.ad?` or `.asc?`.
With this regexp the following URI will *not* match:

```
http://some/uri/with/.ad/index.html
```